### PR TITLE
reference code to load latest C2M2 datapackages

### DIFF
--- a/examples/cfde_datapackage.py
+++ b/examples/cfde_datapackage.py
@@ -1,0 +1,271 @@
+import os
+import json
+import csv
+
+from deriva.core import urlquote, AttrDict
+from deriva.core.ermrest_config import tag
+
+import tableschema2erm
+
+# we'll use this utility function later...
+def topo_sorted(depmap):
+    """Return list of items topologically sorted.
+
+       depmap: { item: [required_item, ...], ... }
+
+    Raises ValueError if a required_item cannot be satisfied in any order.
+
+    The per-item required_item iterables must allow revisiting on
+    multiple iterations.
+
+    """
+    ordered = [ item for item, requires in depmap.items() if not requires ]
+    depmap = { item: set(requires) for item, requires in depmap.items() if requires }
+    satisfied = set(ordered)
+    while depmap:
+        additions = []
+        for item, requires in list(depmap.items()):
+            if requires.issubset(satisfied):
+                additions.append(item)
+                satisfied.add(item)
+                del depmap[item]
+        if not additions:
+            raise ValueError(("unsatisfiable", depmap))
+        ordered.extend(additions)
+        additions = []
+    return ordered
+
+class CfdeDataPackage (object):
+    # the translation stores frictionless table resource metadata under this annotation
+    resource_tag = 'tag:isrd.isi.edu,2019:table-resource'
+    # the translation leaves extranneous table-schema stuff under this annotation
+    # (i.e. stuff that perhaps wasn't translated to deriva equivalents)
+    schema_tag = 'tag:isrd.isi.edu,2019:table-schema-leftovers'
+
+    # some useful group IDs to use later in ACLs...
+    grp = AttrDict({
+        # USC/ISI ISRD roles
+        "isrd_staff": "https://auth.globus.org/176baec4-ed26-11e5-8e88-22000ab4b42b",
+        'isrd_testers':    "https://auth.globus.org/9d596ac6-22b9-11e6-b519-22000aef184d",
+        # demo.derivacloud.org roles
+        "demo_admin": "https://auth.globus.org/5a773142-e2ed-11e8-a017-0e8017bdda58",
+        "demo_creator": "https://auth.globus.org/bc286232-a82c-11e9-8157-0ed6cb1f08e0",
+        "demo_writer": "https://auth.globus.org/caa11064-e2ed-11e8-9d6d-0a7c1eab007a",
+        "demo_curator": "https://auth.globus.org/a5cfa412-e2ed-11e8-a768-0e368f3075e8",
+        "demo_reader": "https://auth.globus.org/b9100ea4-e2ed-11e8-8b39-0e368f3075e8",
+    })
+    writers = [grp.demo_curator, grp.demo_writer]
+    catalog_acls = {
+        "owner": [grp.demo_admin, grp.demo_creator],
+        "insert": writers,
+        "update": writers,
+        "delete": writers,
+        "select": [grp.demo_reader, grp.isrd_testers, grp.isrd_staff],
+        "enumerate": ["*"],
+    }
+
+    def __init__(self, filename):
+        self.filename = filename
+        self.dirname = os.path.dirname(self.filename)
+        self.catalog = None
+        self.model_root = None
+        self.cfde_schema = None
+        
+        with open(self.filename, 'r') as f:
+            tableschema = json.loads(f.read())
+
+        self.model_doc = tableschema2erm.convert_tableschema(tableschema, 'CFDE', True)
+
+        if set(self.model_doc['schemas']) != {'CFDE'}:
+            raise NotImplementedError('Unexpected schema set in data package: %s' % (self.model_doc['schemas'],))
+
+    def set_catalog(self, catalog):
+        self.catalog = catalog
+        self.get_model()
+
+    def get_model(self):
+        self.model_root = self.catalog.getCatalogModel()
+        self.cfde_schema = self.model_root.schemas.get('CFDE')
+
+    def provision(self):
+        if 'CFDE' not in self.model_root.schemas:
+            # blindly load the whole model on an apparently empty catalog
+            self.catalog.post('/schema', json=self.model_doc).raise_for_status()
+        else:
+            # do some naively idempotent model definitions on existing catalog
+            # adding missing tables and missing columns
+            need_tables = []
+            need_columns = []
+            hazard_fkeys = {}
+            for tname, tdoc in self.model_doc['schemas']['CFDE']['tables'].items():
+                if tname in self.cfde_schema.tables:
+                    table = self.cfde_schema.tables[tname]
+                    for cdoc in tdoc['column_definitions']:
+                        if cdoc['name'] in table.column_definitions.elements:
+                            column = table.column_definitions.elements[cdoc['name']]
+                            # TODO: check existing columns for compatibility?
+                        else:
+                            cdoc.update({'table_name': tname, 'nullok': True})
+                            need_columns.append(cdoc)
+                    # TODO: check existing table keys/foreign keys for compatibility?
+                else:
+                    tdoc['schema_name'] = 'CFDE'
+                    need_tables.append(tdoc)
+
+            if need_tables:
+                print("Added tables %s" % ([tdoc['table_name'] for tdoc in need_tables]))
+                self.catalog.post('/schema', json=need_tables).raise_for_status()
+
+            for cdoc in need_columns:
+                self.catalog.post(
+                    '/schema/CFDE/table/%s/column' % urlquote(cdoc['table_name']),
+                    json=cdoc
+                ).raise_for_status()
+                print("Added column %s.%s" % (cdoc['table_name'], cdoc['name']))
+
+        self.get_model()
+
+    def apply_custom_config(self):
+        self.get_model()
+        self.model_root.acls.update(self.catalog_acls)
+
+        # set custom chaise configuration values for this catalog
+        self.model_root.annotations[tag.chaise_config] = {
+            # hide system metadata by default in tabular listings, to focus on CFDE-specific content
+            "SystemColumnsDisplayCompact": [],
+        }
+
+        # have Chaise display underscores in model element names as whitespace
+        self.cfde_schema.display.name_style = {"underline_space": True}
+
+        # prettier display of built-in ERMrest_Client table entries
+        self.model_root.table('public', 'ERMrest_Client').table_display.row_name = {
+            "row_markdown_pattern": "{{{Full_Name}}} ({{{Display_Name}}})"
+        }
+
+        def find_fkey(from_table, from_columns):
+            from_table = self.model_root.table("CFDE", from_table)
+            if isinstance(from_columns, str):
+                from_columns = [from_columns]
+            for fkey in from_table.foreign_keys:
+                if set(from_columns) == set([ c['column_name'] for c in fkey.foreign_key_columns ]):
+                    return fkey
+            raise KeyError(from_columns)
+
+        def assoc_source(markdown_name, assoc_table, left_columns, right_columns, **kwargs):
+            d = {
+                "source": [
+                    {"inbound": find_fkey(assoc_table, left_columns).names[0]},
+                    {"outbound": find_fkey(assoc_table, right_columns).names[0]},
+                    "RID"
+                ],
+                "markdown_name": markdown_name,
+            }
+            d.update(kwargs)
+            return d
+
+        ds_to_file = [
+            {"inbound": find_fkey("FilesInDatasets", "DatasetID").names[0]},
+            {"outbound": find_fkey("FilesInDatasets", "FileID").names[0]},
+        ]
+
+        ds_to_devent = ds_to_file + [
+            {"inbound": find_fkey("ProducedBy", "FileID").names[0]},
+            {"outbound": find_fkey("ProducedBy", "DataEventID").names[0]},
+        ]
+
+        ds_to_bsamp = ds_to_devent + [
+            {"inbound": find_fkey("AssayedBy", "DataEventID").names[0]},
+            {"outbound": find_fkey("AssayedBy", "BioSampleID").names[0]},
+        ]
+        
+        # improve Dataset with pseudo columns?
+        sponsors = assoc_source(
+            "Sponsors", "SponsoredBy", ["DatasetID"], ["OrganizationID"],
+            aggregate="array", array_display="ulist"
+        )
+        
+        self.model_root.table('CFDE', 'Dataset').annotations[tag.visible_columns] = {
+            "compact": ["title", sponsors, "description", "url"],
+            "detailed": ["id", "title", sponsors, "url", "description"],
+            "filter": {"and": [
+                "title",
+                #sponsors,
+                "description",
+                "url",
+                {
+                    "markdown_name": "Data Method",
+                    "source": ds_to_devent + [ {"outbound": find_fkey("DataEvent", "method").names[0]}, "RID" ]
+                },
+                {
+                    "markdown_name": "Data Platform",
+                    "source": ds_to_devent + [ {"outbound": find_fkey("DataEvent", "platform").names[0]}, "RID" ]
+                },
+                {
+                    "markdown_name": "Data Protocol",
+                    "source": ds_to_devent + [ {"outbound": find_fkey("DataEvent", "protocol").names[0]}, "RID" ]
+                },
+                {
+                    "markdown_name": "Biosample Type",
+                    "source": ds_to_bsamp + [ {"outbound": find_fkey("BioSample", "sample_type").names[0]}, "RID" ]
+                },
+                assoc_source("Parent Datasets", "DatasetsInDatasets", ["ContainedDatasetID"], ["ContainingDatasetID"]),
+                assoc_source("Child Datasets", "DatasetsInDatasets", ["ContainingDatasetID"], ["ContainedDatasetID"]),
+                assoc_source("Files", "FilesInDatasets", ["DatasetID"], ["FileID"]),
+            ]}
+        }
+
+        ## apply the above ACL and annotation changes to server
+        self.model_root.apply(self.catalog)
+        self.get_model()
+
+    @classmethod
+    def make_row2dict(cls, table, header):
+        """Pickle a row2dict(row) function for use with a csv reader"""
+        numcols = len(header)
+        missingValues = set(table.annotations[cls.schema_tag].get("missingValues", []))
+
+        for cname in header:
+            if cname not in table.column_definitions.elements:
+                raise ValueError("header column %s not found in table %s" % (cname, table.name))
+
+        def row2dict(row):
+            """Convert row tuple to dictionary of {col: val} mappings."""
+            return dict(zip(
+                header,
+                [ None if x in missingValues else x for x in row ]
+            ))
+
+        return row2dict
+
+    def data_tnames_topo_sorted(self):
+        def target_tname(fkey):
+            return fkey.referenced_columns[0]["table_name"]
+        tables_doc = self.model_doc['schemas']['CFDE']['tables']
+        return topo_sorted({
+            table.name: [
+                target_tname(fkey)
+                for fkey in table.foreign_keys
+                if target_tname(fkey) != table.name and target_tname(fkey) in tables_doc
+            ]
+            for table in self.cfde_schema.tables.values()
+            if table.name in tables_doc
+        })
+
+    def load_data_files(self):
+        tables_doc = self.model_doc['schemas']['CFDE']['tables']
+        for tname in self.data_tnames_topo_sorted():
+            # we are doing a clean load of data in fkey dependency order
+            table = self.model_root.table("CFDE", tname)
+            resource = tables_doc[tname]["annotations"].get(self.resource_tag, {})
+            if "path" in resource:
+                fname = "%s/%s" % (self.dirname, resource["path"])
+                with open(fname, "r") as f:
+                    # translate TSV to python dicts
+                    reader = csv.reader(f, delimiter="\t")
+                    raw_rows = list(reader)
+                    row2dict = self.make_row2dict(table, raw_rows[0])
+                    dict_rows = [ row2dict(row) for row in raw_rows[1:] ]
+                    self.catalog.post("/entity/CFDE:%s" % urlquote(table.name), json=dict_rows)
+                    print("Table %s data loaded from %s." % (table.name, fname))
+

--- a/examples/setup_c2m2_catalog.py
+++ b/examples/setup_c2m2_catalog.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+from deriva.core import DerivaServer, get_credential, urlquote, AttrDict
+from deriva.core.ermrest_config import tag
+
+from cfde_datapackage import CfdeDataPackage
+
+"""
+Basic C2M2 catalog sketch
+
+Demonstrates use of deriva-py APIs:
+- server authentication (assumes active deriva-auth agent)
+- catalog creation
+- model provisioning
+- basic configuration of catalog ACLs
+- small Chaise presentation tweaks via model annotations
+- simple insertion of tabular content
+
+Examples:
+
+   python3 ./examples/setup_c2m2_catalog.py ./table-schema/cfde-core-model.json
+
+   python3 /path/to/GTEx.v7.C2M2_preload.bdbag/data/GTEx_C2M2_instance.json
+
+when the JSON includes "path" attributes for the resources, as in the
+second example above, the data files (TSV assumed) are loaded for each
+resource after the schema is provisioned.
+
+"""
+
+# this is the deriva server where we will create a catalog
+servername = 'demo.derivacloud.org'
+
+## bind to server
+credentials = get_credential(servername)
+server = DerivaServer('https', servername, credentials)
+
+# ugly quasi CLI...
+if len(sys.argv) != 2:
+    raise ValueError('One data package JSON filename required as argument')
+
+# pre-load all JSON files and convert to models
+# in order to abort early on basic usage errors
+dp = CfdeDataPackage(sys.argv[1])
+
+
+## create catalog
+catalog = server.create_ermrest_catalog()
+print('New catalog has catalog_id=%s' % catalog.catalog_id)
+print("Don't forget to delete it if you are done with it!")
+
+## deploy model(s)
+dp.set_catalog(catalog)
+dp.provision()
+print("Model deployed for %s." % (dp.filename,))
+
+
+## load some sample data?
+dp.load_data_files()
+
+print("All data packages loaded.")
+
+print("Try visiting 'https://%s/chaise/recordset/#%s/CFDE:Dataset'" % (
+    servername,
+    catalog.catalog_id,
+))
+
+# catalog.delete_ermrest_catalog(really=True)

--- a/examples/setup_c2m2_catalog.py
+++ b/examples/setup_c2m2_catalog.py
@@ -57,6 +57,8 @@ dp.set_catalog(catalog)
 dp.provision()
 print("Model deployed for %s." % (dp.filename,))
 
+# set acls
+dp.apply_acls()
 
 ## load some sample data?
 dp.load_data_files()

--- a/examples/tableschema2erm.py
+++ b/examples/tableschema2erm.py
@@ -1,0 +1,129 @@
+"""Translate basic Frictionless Table-Schema table definitions to Deriva.
+
+convert_tableschema(tableschema, schema_name = 'CFDE', skip_system_cols = False)
+returns ERM schema as dictionary
+
+"""
+
+import json
+from deriva.core.ermrest_model import builtin_types, Table, Column, Key, ForeignKey
+
+schema_tag = 'tag:isrd.isi.edu,2019:table-schema-leftovers'
+resource_tag = 'tag:isrd.isi.edu,2019:table-resource'
+
+def make_type(type, format):
+    """Choose appropriate ERMrest column types..."""
+    if type == "string":
+        return builtin_types.text
+    if type == "datetime":
+        return builtin_types.timestamptz
+    if type == "date":
+        return builtin_types.date
+    if type == "integer":
+        return builtin_types.int8
+    if type == "number":
+        return builtin_types.float8
+    if type == "list":
+        # assume a list is a list of strings for now...
+        return builtin_types["text[]"]
+    raise ValueError('no mapping defined yet for type=%s format=%s' % (type, format))
+
+def make_column(cdef):
+    cdef = dict(cdef)
+    constraints = cdef.get("constraints", {})
+    cdef_name = cdef.pop("name")
+    nullok = not constraints.pop("required", False)
+    description = cdef.pop("description", None)
+    return Column.define(
+        cdef_name,
+        make_type(
+            cdef.get("type", "string"),
+            cdef.get("format", "default"),
+        ),
+        nullok=nullok,
+        comment=description,
+        annotations={
+            schema_tag: cdef,
+        }
+    )
+
+def make_key(tname, cols, schema_name):
+    return Key.define(
+        cols,
+        constraint_names=[ [schema_name, "%s_%s_key" % (tname, "_".join(cols))] ],
+    )
+
+def make_fkey(tname, fkdef, schema_name):
+    fkcols = fkdef.pop("fields")
+    fkcols = [fkcols] if isinstance(fkcols, str) else fkcols
+    reference = fkdef.pop("reference")
+    pktable = reference.pop("resource")
+    pktable = tname if pktable == "" else pktable
+    pkcols = reference.pop("fields")
+    pkcols = [pkcols] if isinstance(pkcols, str) else pkcols
+    return ForeignKey.define(
+        fkcols,
+        schema_name,
+        pktable,
+        pkcols,
+        constraint_names=[ [schema_name, "%s_%s_fkey" % (tname, "_".join(fkcols))] ],
+        annotations={
+            schema_tag: fkdef,
+        }
+    )
+
+def make_table(tdef, schema_name, skip_system_cols = False):
+    tname = tdef["name"]
+    tcomment = tdef.get("description")
+    tdef_resource = tdef
+    tdef = tdef_resource.pop("schema")
+    keys = []
+    keysets = set()
+    pk = tdef.pop("primaryKey", None)
+    if isinstance(pk, str):
+        pk = [pk]
+    if isinstance(pk, list):
+        keys.append(make_key(tname, pk, schema_name))
+        keysets.add(frozenset(pk))
+    tdef_fields = tdef.pop("fields", None)
+    for cdef in tdef_fields:
+        if cdef.get("constraints", {}).pop("unique", False):
+            kcols = [cdef["name"]]
+            if frozenset(kcols) not in keysets:
+                keys.append(make_key(tname, kcols, schema_name))
+                keysets.add(frozenset(kcols))
+    tdef_fkeys = tdef.pop("foreignKeys", [])
+    return Table.define(
+        tname,
+        column_defs=[
+            make_column(cdef)
+            for cdef in tdef_fields
+        ],
+        key_defs=keys,
+        fkey_defs=[
+            make_fkey(tname, fkdef, schema_name)
+            for fkdef in tdef_fkeys
+        ],
+        comment=tcomment,
+        provide_system=skip_system_cols,
+        annotations={
+            resource_tag: tdef_resource,
+            schema_tag: tdef,
+        }
+    )
+
+def convert_tableschema(tableschema, schema_name = 'CFDE', skip_system_cols = False):
+    resources = tableschema['resources']
+    deriva_schema = {
+        "schemas": {
+            schema_name: {
+                "schema_name": schema_name,
+                "tables": {
+                    tdef["name"]: make_table(tdef, schema_name, skip_system_cols)
+                    for tdef in resources
+                }
+            }
+        }
+    }
+    return deriva_schema
+

--- a/examples/tableschema_to_deriva.py
+++ b/examples/tableschema_to_deriva.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+"""Translate basic Frictionless Table-Schema table definitions to Deriva.
+
+- Reads table-schema JSON on standard input
+- Writes deriva schema JSON on standard output
+
+The output JSON is suitable for POST to an /ermrest/catalog/N/schema
+resource on a fresh, empty catalog.
+
+Example:
+
+   cd cfde-deriva
+   python3 examples/tableschema_to_deriva.py \
+     < table-schema/cfde-core-model.json
+
+Optionally:
+
+   run with SKIP_SYSTEM_COLUMNS=true to suppress generation of ERMrest
+   system columns RID,RCT,RCB,RMT,RMB for each table.
+
+"""
+
+import os
+import sys
+import json
+import tableschema2erm
+
+tableschema = json.load(sys.stdin)
+skip_system_cols = not (os.getenv('SKIP_SYSTEM_COLUMNS', 'false').lower() == 'true')
+deriva_schema = tableschema2erm.convert_tableschema(tableschema, 'CFDE', skip_system_cols)
+json.dump(deriva_schema, sys.stdout, indent=2)


### PR DESCRIPTION
@jgaff look at `setup_c2m2_catalog.py` it goes through all of Karl's steps to create the schema and load the data files. It imports `cfde_datapackage.py`, which does the work. The `cfde_datapackage.py` imports `tableschema2erm.py` which converts between tableschema and erm. `tableschema_to_deriva.py` is a test script for that.

From here you should be able to use Mike's example of `bdbag --materialize https://examples.fair-research.org/public/CFDE/metadata/CFDE-all.v4.C2M2.bdbag.tgz` and `bdbag --materialize https://examples.fair-research.org/public/CFDE/metadata/CFDE-GTEx-v7.v0.C2M2.bdbag.tgz` or whatever you have in place to pull the BDBags and then run the steps in `setup_c2m2_catalog.py` on the JSON files.